### PR TITLE
Bump TOC Versions

### DIFF
--- a/Speaketh.toc
+++ b/Speaketh.toc
@@ -1,11 +1,10 @@
-##==================================
-## Interface: 120005
+## Interface: 120007
 ## Title: Speaketh
 ## Notes: Auto-translate chat into WoW racial languages and Shath'Yar. Switch languages via minimap button.
 ## Author: BattRatt
-## Version: 1.0.5
+## Version: 1.0.6
 ## SavedVariablesPerCharacter: Speaketh_Char
-##==================================
+
 
 ## IconTexture: Interface\AddOns\Speaketh\Resources\Speaketh32
 ## Category-enUS: Roleplay


### PR DESCRIPTION
Bumped Interface and Version numbers for 12.0.7
Removed comment markers to avoid potential issues in 12.0.7, gave me issues. Being overzealous.